### PR TITLE
adding setTimeout to prevent wrapping on certain resize scenarios

### DIFF
--- a/src/smart-text.component.ts
+++ b/src/smart-text.component.ts
@@ -1,6 +1,7 @@
-import { AfterContentInit, AfterViewInit, ChangeDetectorRef, Component,
-  ElementRef, EventEmitter, Input, Renderer, Output, ViewChild, OnChanges
-  } from '@angular/core';
+import {
+  AfterContentInit, AfterViewInit, ChangeDetectorRef, Component,
+  ElementRef, EventEmitter, Input, Renderer, Output, ViewChild, OnChanges, OnDestroy
+} from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
@@ -23,7 +24,7 @@ export type ModeType = 'display' | 'edit' | 'popout';
   template: require('./smart-text.component.html'),
   styles: [require('./smart-text.component.scss')]
 })
-export class SmartTextComponent implements AfterContentInit, AfterViewInit, OnChanges {
+export class SmartTextComponent implements AfterContentInit, AfterViewInit, OnChanges, OnDestroy {
 
   // ------ Properties -------------------------------------------------------
 
@@ -44,6 +45,7 @@ export class SmartTextComponent implements AfterContentInit, AfterViewInit, OnCh
 
   subscriptions: Array<ISubscription> = [];
   timeout: any;
+  resizeTimeout: number;
   nativeEl: any;
   height: any;
   offsets: any;
@@ -107,7 +109,9 @@ export class SmartTextComponent implements AfterContentInit, AfterViewInit, OnCh
         .subscribe((text) => this.editText.nativeElement.value = text),
       this.resize$.combineLatest(this.fullText$)
         .map(([, text]) => text)
-        .subscribe(this.shaveText.bind(this)),
+        .subscribe((text) =>
+          this.resizeTimeout = setTimeout(() => this.shaveText(text))
+        ),
       this.reshave.combineLatest(this.fullText$)
         .map(([, text]) => text)
         .subscribe((text) =>
@@ -139,6 +143,7 @@ export class SmartTextComponent implements AfterContentInit, AfterViewInit, OnCh
 
   public ngOnDestroy() {
     clearTimeout(this.timeout);
+    clearTimeout(this.resizeTimeout);
     this.destroySubscribers();
   }
 

--- a/tslint.json
+++ b/tslint.json
@@ -99,7 +99,7 @@
     ],
 
     "directive-selector": [true, "attribute", "app", "camelCase"],
-    "component-selector": [true, "element", "app", "kebab-case"],
+    "component-selector": [true, "element", "supre", "kebab-case"],
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
     "use-host-property-decorator": true,


### PR DESCRIPTION
When a delayed resize occurred, shaveText was not running.  I observed this happening in the audience builder when adding 7 or more attributes.  Story: https://jira.inbcu.com/browse/AUG-552
